### PR TITLE
Update _stats.html.twig

### DIFF
--- a/Resources/views/_stats.html.twig
+++ b/Resources/views/_stats.html.twig
@@ -1,8 +1,8 @@
 {# KilikTableBundle::_stats.html.twig #}
 
 {% if tableRenderStats is defined %}
-    {{ "kiliktable.showing_entries"|transchoice(table.filteredRows,{"%firstRow%": table.firstRow,"%lastRow%": table.lastRow,"%filteredRows%":table.filteredRows})|capitalize }}
-    {% if table.filteredRows != table.totalRows and table.totalRows > 0%}
-        ({{ "kiliktable.filtered_from"|transchoice(table.totalRows,{"%totalRows%":table.totalRows})|capitalize }})
+    {{ "kiliktable.showing_entries"|trans({"%count%" : table.filteredRows, "%firstRow%": table.firstRow,"%lastRow%": table.lastRow,"%filteredRows%":table.filteredRows})|capitalize }}
+    {% if table.filteredRows != table.totalRows and table.totalRows > 0 %}
+        ({{ "kiliktable.filtered_from"|trans({"%count%": table.totalRows, "%totalRows%":table.totalRows})|capitalize }})
     {% endif %}
 {% endif %}


### PR DESCRIPTION
User Deprecated: Twig Filter "transchoice" is deprecated since version 4.2. Use "trans" with parameter "%count%" instead in /var/www/html/templates/bundles/KilikTableBundle/_stats.html.twig at line 4.